### PR TITLE
Allows setting a reason to the @deprecated tag

### DIFF
--- a/src/main/resources/default/file.ftl
+++ b/src/main/resources/default/file.ftl
@@ -123,8 +123,8 @@ function setTitle() {
         </code></dt>
         <dd>
             <br>
-	    <#if macro.@deprecated??> 
-                <@printDeprecated/>
+	    <#if macro.@deprecated??>
+                <@printDeprecated macro.@deprecated/>
             </#if>
             <#if macro.comment?has_content>
                 ${macro.comment}<br><br>
@@ -173,8 +173,9 @@ function setTitle() {
 </#if>
 </#macro>
 
-<#macro printDeprecated>
-    <dt>⚠ Deprecated</dt>
+<#macro printDeprecated reason>
+    <dt>⚠ Deprecated<#if reason?? && reason?trim?length != 0>: ${reason}</#if>
+    </dt><br />
 </#macro>
 
 <#macro signature macro>


### PR DESCRIPTION
For Example you can have
```
@deprecated because it was a poorly thought out macro
```
and the reason `because it was a poorly thought out macro` will show in the doco.