### PR TITLE
Fixes and improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,38 +1,58 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>freemarker</groupId>
-	<artifactId>ftldoc-maven-plugin</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
-	<name>FreeMarker documentation generator - Maven plugin</name>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>freemarker</groupId>
+    <artifactId>ftldoc-maven-plugin</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
+    <name>FreeMarker documentation generator - Maven plugin</name>
 
-	<packaging>maven-plugin</packaging>
+    <packaging>maven-plugin</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.freemarker</groupId>
-			<artifactId>freemarker</artifactId>
-			<version>2.3.26-incubating</version>
-			<type>jar</type>
-		</dependency>
+    <prerequisites>
+        <maven>3.3.0</maven>
+    </prerequisites>
 
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>3.3.9</version>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>2.3.26-incubating</version>
+            <type>jar</type>
+        </dependency>
 
-		<!-- dependencies to annotations -->
-		<dependency>
-			<groupId>org.apache.maven.plugin-tools</groupId>
-			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.4</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.3.9</version>
+        </dependency>
 
-	</dependencies>
+        <!-- dependencies to annotations -->
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.4</version>
+            <scope>provided</scope>
+        </dependency>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>

--- a/src/main/java/freemarker/tools/ftldoc/FtlDoc.java
+++ b/src/main/java/freemarker/tools/ftldoc/FtlDoc.java
@@ -88,6 +88,7 @@ import freemarker.template.Configuration;
 import freemarker.template.SimpleHash;
 import freemarker.template.SimpleSequence;
 import freemarker.template.Template;
+import freemarker.template.Version;
 
 
 /**
@@ -98,6 +99,7 @@ import freemarker.template.Template;
 public class FtlDoc {
     
     private static final String EXT_FTL = ".ftl";
+    private static final String OUTPUT_ENCODING = "UTF-8";
     
     private static final Comparator<Map<String, Object>> MACRO_COMPARATOR = new Comparator<Map<String, Object>>() {
         @Override
@@ -142,8 +144,9 @@ public class FtlDoc {
     
     
     public FtlDoc(List<File> files, File outputDir, File altTemplatesFolder) {
-        cfg = new Configuration();
+        cfg = new Configuration(Configuration.VERSION_2_3_26); // TODO parametrice version compatibility
         cfg.setWhitespaceStripping(false);
+        cfg.setOutputEncoding(OUTPUT_ENCODING);
         
         fOutDir = outputDir;
         fFiles = files;
@@ -151,10 +154,7 @@ public class FtlDoc {
         
         // extracting parent directories of all files
         fAllDirectories = new HashSet<File>();
-        Iterator iter = files.iterator();
-        while (iter.hasNext())
-        {
-            File f = (File)iter.next();
+        for (File f : files) {
             fAllDirectories.add(f.getParentFile());
         }
         
@@ -326,7 +326,7 @@ public class FtlDoc {
             root.put("categories",categories);
             
             try (OutputStreamWriter outputStream = new OutputStreamWriter (
-                    new FileOutputStream (htmlFile), Charset.forName("UTF-8").newEncoder()))
+                    new FileOutputStream (htmlFile), Charset.forName(OUTPUT_ENCODING).newEncoder()))
             {
                 t_out.process(root, outputStream);
             }
@@ -342,9 +342,7 @@ public class FtlDoc {
      */
     public void run() {
      
-        try
-        {
-            
+        try {
             // init global collections
             allCategories = new TreeMap<String, List<Map<String, Object>>>();
             allMacros = new ArrayList<Map<String, Object>>();
@@ -397,7 +395,7 @@ public class FtlDoc {
     private void createIndexPage() {
         File indexFile = new File(fOutDir,"index.html");
         try (OutputStreamWriter outputStream = new OutputStreamWriter (
-                    new FileOutputStream (indexFile), Charset.forName("UTF-8").newEncoder()))
+                    new FileOutputStream (indexFile), Charset.forName(OUTPUT_ENCODING).newEncoder()))
         {
             Template template = cfg.getTemplate(Templates.index.fileName());
             template.process(null, outputStream);
@@ -407,7 +405,7 @@ public class FtlDoc {
     private void createAllCatPage() {
         File categoryFile = new File(fOutDir,"index-all-cat.html");
         try (OutputStreamWriter outputStream = new OutputStreamWriter (
-                    new FileOutputStream (categoryFile), Charset.forName("UTF-8").newEncoder()))
+                    new FileOutputStream (categoryFile), Charset.forName(OUTPUT_ENCODING).newEncoder()))
         {
             SimpleHash root = new SimpleHash();
             root.put("categories", allCategories);
@@ -419,7 +417,7 @@ public class FtlDoc {
     private void createAllAlphaPage() {
         File allAlphaFile = new File(fOutDir,"index-all-alpha.html");
         try (OutputStreamWriter outputStream = new OutputStreamWriter (
-                    new FileOutputStream (allAlphaFile), Charset.forName("UTF-8").newEncoder()))
+                    new FileOutputStream (allAlphaFile), Charset.forName(OUTPUT_ENCODING).newEncoder()))
         {
             SimpleHash root = new SimpleHash();
             Collections.sort(allMacros, MACRO_COMPARATOR);
@@ -432,7 +430,7 @@ public class FtlDoc {
     private void createOverviewPage() {
         File overviewFile = new File(fOutDir,"overview.html");
         try (OutputStreamWriter outputStream = new OutputStreamWriter (
-                    new FileOutputStream (overviewFile), Charset.forName("UTF-8").newEncoder()))
+                    new FileOutputStream (overviewFile), Charset.forName(OUTPUT_ENCODING).newEncoder()))
         {
             Template template = cfg.getTemplate(Templates.overview.fileName());
             Map<String, List> root = new HashMap<String, List>();
@@ -450,7 +448,7 @@ public class FtlDoc {
         
         File filelistFile = new File(fOutDir,"files.html");
         try (OutputStreamWriter outputStream = new OutputStreamWriter (
-                    new FileOutputStream (filelistFile), Charset.forName("UTF-8").newEncoder()))
+                    new FileOutputStream (filelistFile), Charset.forName(OUTPUT_ENCODING).newEncoder()))
         {
             SimpleHash root = new SimpleHash();
             root.put("suffix",suffix);

--- a/src/main/java/freemarker/tools/ftldoc/FtlDocMojo.java
+++ b/src/main/java/freemarker/tools/ftldoc/FtlDocMojo.java
@@ -1,10 +1,8 @@
 package freemarker.tools.ftldoc;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -15,7 +13,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "generate-documentation")
 public class FtlDocMojo extends AbstractMojo {
 
-    @Parameter( property = "outputDirectory", required=true)
+    @Parameter( property = "outputDirectory", required=true, defaultValue ="${project.build.directory}/ftldocs")
     private File outputDirectory;
 
     @Parameter( property = "templateDirectory")

--- a/src/main/java/freemarker/tools/ftldoc/FtlDocMojo.java
+++ b/src/main/java/freemarker/tools/ftldoc/FtlDocMojo.java
@@ -1,7 +1,11 @@
 package freemarker.tools.ftldoc;
 
 import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -11,22 +15,52 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "generate-documentation")
 public class FtlDocMojo extends AbstractMojo {
 
-    @Parameter( property = "outputDirectory")
+    @Parameter( property = "outputDirectory", required=true)
     private File outputDirectory;
 
     @Parameter( property = "templateDirectory")
     private File templateDirectory;
 
-    @Parameter( property = "freemarkerFiles")
+    @Parameter( property = "freemarkerFiles", required=true)
     private File[] freemarkerFiles;
 
+    @Parameter( property = "freemarkerFileExtesion")
+    private String freemarkerFileExtension;
+
     public void execute() throws MojoExecutionException {
-        getLog().info( "Will generate doc into " + outputDirectory + " based on templates from " + templateDirectory );
-        getLog().info( "Files to process: " + Arrays.asList(freemarkerFiles));
+        if (this.freemarkerFiles.length == 0) {
+            getLog().error("Required parameter 'freemarkerFiles' is empty. Please fill it.");
+            return;
+        }
+        List<File> ftlFiles = this.expandFiles(Arrays.asList(freemarkerFiles));
+        
+        getLog().info( "Will generate doc into " + outputDirectory);
+        if (this.templateDirectory != null) {
+            getLog().info("With templates from " + templateDirectory );
+        }
+        getLog().info( "Files to process in: " + Arrays.asList(freemarkerFiles));
+        if (this.freemarkerFileExtension != null) {
+            getLog().info("Files filtered by extesion : " + this.freemarkerFileExtension);
+        }
         outputDirectory.mkdirs();
-        FtlDoc ftl = new FtlDoc(Arrays.asList(freemarkerFiles), outputDirectory, templateDirectory);
+        FtlDoc ftl = new FtlDoc(ftlFiles, outputDirectory, templateDirectory);
         ftl.run();
         getLog().info( "Finished generating doc" );
     }
 
+    
+    private List<File>  expandFiles (List<File> paramFiles) {
+        List<File> realFreemarkerFiles = new ArrayList<File>();
+        for (File f : paramFiles) {
+            if (f.isFile()) {
+                if (this.freemarkerFileExtension == null 
+                        || f.getName().endsWith(this.freemarkerFileExtension)) {
+                    realFreemarkerFiles.add (f);
+                }
+            } else if (f.isDirectory()) {
+                realFreemarkerFiles.addAll(this.expandFiles( Arrays.asList(f.listFiles())));
+            }
+        }
+        return realFreemarkerFiles;
+    }
 }

--- a/src/main/java/freemarker/tools/ftldoc/FtlDocMojo.java
+++ b/src/main/java/freemarker/tools/ftldoc/FtlDocMojo.java
@@ -13,7 +13,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "generate-documentation")
 public class FtlDocMojo extends AbstractMojo {
 
-    @Parameter( property = "outputDirectory", required=true, defaultValue ="${project.build.directory}/ftldocs")
+    @Parameter( property = "outputDirectory", defaultValue ="${project.build.directory}/ftldocs")
     private File outputDirectory;
 
     @Parameter( property = "templateDirectory")
@@ -22,7 +22,7 @@ public class FtlDocMojo extends AbstractMojo {
     @Parameter( property = "freemarkerFiles", required=true)
     private File[] freemarkerFiles;
 
-    @Parameter( property = "freemarkerFileExtesion")
+    @Parameter( property = "freemarkerFileExtesion", defaultValue ="ftl")
     private String freemarkerFileExtension;
 
     public void execute() throws MojoExecutionException {

--- a/src/main/resources/default/file.ftl
+++ b/src/main/resources/default/file.ftl
@@ -2,60 +2,58 @@
 
 <html>
 <head>
-<title>
-ftldoc
-</title>
-<link rel="stylesheet" type="text/css" href="eclipse.css" />
-<style>
-table {
-    width: 100%;
-}
-td {
-    background-color: White;
-}
-td.heading {
-    padding: 3px;
-    font-weight: bold;
-    font-size: 18px;
-    background-color: #CCCCFF;
-}
-td.category {
-    padding: 3px;
-    font-weight: bold;
-    font-size: 14px;
-    background-color: #DDDDFF;
-}
-div.sourcecode {
-    display: none;
-    border : 1px solid Black;
-    background-color : #DDDDDD; /* #E8E8E8; */
-    padding : 3px;
-    margin-top : 8px;
-}
+    <meta charset="${.output_encoding}" />
+    <title>ftldoc</title>
+    <link rel="stylesheet" type="text/css" href="eclipse.css" />
+    <style>
+        table {
+            width: 100%;
+        }
+        td {
+            background-color: White;
+        }
+        td.heading {
+            padding: 3px;
+            font-weight: bold;
+            font-size: 18px;
+            background-color: #CCCCFF;
+        }
+        td.category {
+            padding: 3px;
+            font-weight: bold;
+            font-size: 14px;
+            background-color: #DDDDFF;
+        }
+        div.sourcecode {
+            display: none;
+            border : 1px solid Black;
+            background-color : #DDDDDD; /* #E8E8E8; */
+            padding : 3px;
+            margin-top : 8px;
+        }
 
 
-span {font-family:Courier; font-size:12px}
-span.directive {color:blue}
-span.userdirective {color:red}
-span.interpolation {color:green}
-span.textblock {color:black}
-span.comment {color:brown}
+        span {font-family:Courier; font-size:12px}
+        span.directive {color:blue}
+        span.userdirective {color:red}
+        span.interpolation {color:green}
+        span.textblock {color:black}
+        span.comment {color:brown}
+    </style>
+    <script language="javascript">
+        function toggle(id) {
+            elem = document.getElementById(id);
+            if(elem.style.display=="block") {
+                elem.style.display="none";
+            } else {
+                elem.style.display="block";
+            }
+        }
 
-</style>
-<script language="javascript">
-function toggle(id) {
-    elem = document.getElementById(id);
-    if(elem.style.display=="block") {
-        elem.style.display="none";
-    } else {
-        elem.style.display="block";
-    }
-}
-
-function setTitle() {
-	parent.document.title="${filename}";
-}
-</script>
+        function setTitle() {
+            parent.document.title="${filename}";
+        }
+    </script>
 </head>
 <body onLoad="setTitle();">
 <#include "nav.ftl">
@@ -123,7 +121,7 @@ function setTitle() {
         </code></dt>
         <dd>
             <br>
-	    <#if macro.@deprecated??>
+        <#if macro.@deprecated??>
                 <@printDeprecated macro.@deprecated/>
             </#if>
             <#if macro.comment?has_content>
@@ -147,34 +145,34 @@ function setTitle() {
 </html>
 
 <#macro printParameters macro>
-<#if macro.@param?has_content>
-<dt><b>Parameters</b></dt>
-<dd>
-<#list macro.@param as param>
-<code>${param.name}</code> - ${param.description}<br>
-</#list>
-</dd>
-</#if>
+    <#if macro.@param?has_content>
+        <dt><b>Parameters</b></dt>
+        <dd>
+            <#list macro.@param as param>
+                <code>${param.name}</code> - ${param.description}<br>
+            </#list>
+        </dd>
+    </#if>
 </#macro>
 
 <#macro printSourceCode macro>
-<dt><a href="javascript:toggle('sc_${macro.name}');">Source Code</a></dt>
-<dd>
-<div class="sourcecode" id="sc_${macro.name}">
-<@ftl.print root=macro.node/>
-</div>
-</dd>
+    <dt><a href="javascript:toggle('sc_${macro.name}');">Source Code</a></dt>
+    <dd>
+        <div class="sourcecode" id="sc_${macro.name}">
+            <@ftl.print root=macro.node/>
+        </div>
+    </dd>
 </#macro>
 
 <#macro printOptional value label>
-<#if value?has_content>
-<dt><b>${label}</b></dt>
-<dd>${value}</dd>
-</#if>
+    <#if value?has_content>
+        <dt><b>${label}</b></dt>
+        <dd>${value}</dd>
+    </#if>
 </#macro>
 
 <#macro printDeprecated reason>
-    <dt>⚠ Deprecated<#if reason?? && reason?trim?length != 0>: ${reason}</#if>
+    <dt>&#9888; Deprecated<#if reason?? && reason?trim?length != 0>: ${reason}</#if>
     </dt><br />
 </#macro>
 

--- a/src/main/resources/default/filelist.ftl
+++ b/src/main/resources/default/filelist.ftl
@@ -1,4 +1,7 @@
 <html>
+<head>
+    <meta charset="${.output_encoding}" />
+</head>
 <body>
 <h3>Macro Libraries</h3>
 <#list files as file>

--- a/src/main/resources/default/index-all-alpha.ftl
+++ b/src/main/resources/default/index-all-alpha.ftl
@@ -1,40 +1,34 @@
 <html>
 <head>
-<script language="javascript">
-function setTitle() {
-	parent.document.title="ftldoc - Index";
-}
-</script>
+    <meta charset="${.output_encoding}" />
+    <script language="javascript">
+    function setTitle() {
+        parent.document.title="ftldoc - Index";
+    }
+    </script>
 </head>
 <body onLoad="setTitle();">
- <#include "nav.ftl">
- <br>
- <#assign lastLetter = "" />
-                <#list macros as macro>
-                
-<#if macro.name[0]?cap_first != lastLetter>
-<#assign lastLetter = macro.name[0]?cap_first />
-<a href="#${lastLetter}">${lastLetter}</a>
-</#if>
-                            
-                </#list>
- <hr>
+<#include "nav.ftl">
+<br/>
+<#assign lastLetter = "" />
+<#list macros as macro>
+    <#if macro.name[0]?cap_first != lastLetter>
+        <#assign lastLetter = macro.name[0]?cap_first />
+        <a href="#${lastLetter}">${lastLetter}</a>
+    </#if>
+</#list>
+<hr>
  
  
 <#assign lastLetter = "" />
-                <#list macros as macro>
-                
-<#if macro.name[0]?cap_first != lastLetter>
-<#assign lastLetter = macro.name[0]?cap_first />
-<a name="${lastLetter}" /><h3>${lastLetter}</h3>
-</#if>
-                            <b><a href="${macro.filename}.html#${macro.name}">
-                                            ${macro.name}</a>
-                                        </b> - ${macro.type?cap_first} in file
-<a href="${macro.filename}.html">${macro.filename}</a>
-                <br>
-                </#list>
-                
-                
-                </body>
-                </html>
+<#list macros as macro>
+    <#if macro.name[0]?cap_first != lastLetter>
+        <#assign lastLetter = macro.name[0]?cap_first />
+        <a name="${lastLetter}" /><h3>${lastLetter}</h3>
+    </#if>
+    <b><a href="${macro.filename}.html#${macro.name}">${macro.name}</a></b>
+     - ${macro.type?cap_first} in file <a href="${macro.filename}.html">${macro.filename}</a>
+    <br/>
+</#list>
+</body>
+</html>

--- a/src/main/resources/default/index-all-cat.ftl
+++ b/src/main/resources/default/index-all-cat.ftl
@@ -1,32 +1,31 @@
 <html>
 <head>
-<script language="javascript">
-function setTitle() {
-	parent.document.title="ftldoc - Index";
-}
-</script>
+    <meta charset="${.output_encoding}" />
+    <script language="javascript">
+    function setTitle() {
+        parent.document.title="ftldoc - Index";
+    }
+    </script>
 </head>
 <body onLoad="setTitle();">
  <#include "nav.ftl">
-        <#list categories?keys as category>
-            <#if categories[category]?has_content>
-                <#if category?has_content>
-                <h3>Category ${category}</h3>
-                <#else>
-                <h3>no category</h3>
-                </#if>
-                <#list categories[category] as macro>
-                
-                
-                            <b><a href="${macro.filename}.html#${macro.name}">
-                                            ${macro.name}</a>
-                                        </b> - ${macro.type?cap_first} in file
-<a href="${macro.filename}.html">${macro.filename}</a>
-                <br>
-                </#list>
-                <br>
-                <#if category_has_next><hr></#if>
-            </#if>
+<#list categories?keys as category>
+    <#if categories[category]?has_content>
+        <#if category?has_content>
+            <h3>Category ${category}</h3>
+        <#else>
+            <h3>no category</h3>
+        </#if>
+        
+        <#list categories[category] as macro>
+            <b><a href="${macro.filename}.html#${macro.name}">${macro.name}</a></b>
+             - ${macro.type?cap_first} in file
+            <a href="${macro.filename}.html">${macro.filename}</a>
+            <br/>
         </#list>
+        <br/>
+        <#if category_has_next><hr/></#if>
+    </#if>
+</#list>
 </body>
 </html>

--- a/src/main/resources/default/index.ftl
+++ b/src/main/resources/default/index.ftl
@@ -1,5 +1,8 @@
 <html>
-    <head><title>ftldoc</title></head>
+    <head>
+    <meta charset="${.output_encoding}" />
+    <title>ftldoc</title>
+    </head>
     <frameset cols="180,*">
         <frame name="list" src="files.html">
         <frame name="main" src="overview.html">

--- a/src/main/resources/default/nav.ftl
+++ b/src/main/resources/default/nav.ftl
@@ -7,7 +7,7 @@
 
 
 <div style="padding: 3px; font-weight: bold; background-color: #DDDDFF;">
-<a href="overview.html">Overview</a>
-<a href="index-all-cat.html">Index (categorical)</a>
-<a href="index-all-alpha.html">Index (alphabetical)</a>
+    <a href="overview.html">Overview</a>
+    <a href="index-all-cat.html">Index (categorical)</a>
+    <a href="index-all-alpha.html">Index (alphabetical)</a>
 </div>

--- a/src/main/resources/default/overview.ftl
+++ b/src/main/resources/default/overview.ftl
@@ -1,24 +1,25 @@
 <html>
 <head>
-<script language="javascript">
-function setTitle() {
-	parent.document.title="ftldoc - Overview";
-}
-</script>
-<style>
-table {
-    width: 100%;
-}
-td {
-    background-color: White;
-}
-td.heading {
-    padding: 3px;
-    font-weight: bold;
-    font-size: 18px;
-    background-color: #CCCCFF;
-}
-</style>
+    <meta charset="${.output_encoding}" />
+    <script language="javascript">
+    function setTitle() {
+        parent.document.title="ftldoc - Overview";
+    }
+    </script>
+    <style>
+    table {
+        width: 100%;
+    }
+    td {
+        background-color: White;
+    }
+    td.heading {
+        padding: 3px;
+        font-weight: bold;
+        font-size: 18px;
+        background-color: #CCCCFF;
+    }
+    </style>
 </head>
 <body onLoad="setTitle();">
 <#include "nav.ftl">
@@ -26,12 +27,12 @@ td.heading {
 
 <table border="1" cellpadding="4">
     <tr><td colspan="2" class="heading">Library Summary</td></tr>
-	<#list files as file>
-	<tr>
-		<td width="160px"><a href="${file.filename}.html"><b>${file.filename}</b></a></td>
-		<td>${file.comment.short_comment?if_exists}&nbsp;</td>
-	</tr>
-	</#list>
+    <#list files as file>
+        <tr>
+            <td width="160px"><a href="${file.filename}.html"><b>${file.filename}</b></a></td>
+            <td>${file.comment.short_comment?if_exists}&nbsp;</td>
+        </tr>
+    </#list>
 </table>
 </body>
 </html>


### PR DESCRIPTION
* Fix encoding bug . Now outputs UTF-8 files always, and HTML files are set to the correct <meta encoding /> value.
* Default value for "outputDirectory" parameter
* "freemarkerFiles" marked as required
* "freemarkerFiles" now accepts directory paths and now can search freemarker files on these directory and his descendants.
* "freemarkerFileExtesion" with default value "ftl" to control the search of freemaker files on directories.
* More consistent indenting of default template files.
* Fixed @param with multiline description.

TODO : The output encoding, should be controlled by a parameter if is necessary.
TODO : Control freemaker version compatibility with a parameter. Actually is set to 2.3.26